### PR TITLE
修复Linux环境下标题栏和菜单栏显示不正确的问题

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1,9 +1,11 @@
 import { app, protocol, BrowserWindow, Menu } from "electron";
 import { createProtocol } from "vue-cli-plugin-electron-builder/lib";
 import * as path from "path";
+
 import { getRollbackFunc, RollbackFunc } from "@/electron/ConfigureRoleback";
 import { handleIpc } from "@/electron/ipc/IpcHandler";
 import { configureEvent } from "@/electron/ConfiguerEvent";
+import {configureGlobalShortcut} from "@/electron/ConfigureGlobalShortcut";
 
 // Scheme must be registered before the app is ready
 protocol.registerSchemesAsPrivileged([
@@ -12,6 +14,7 @@ protocol.registerSchemesAsPrivileged([
 let rollbackFunc: RollbackFunc | null = null;
 
 async function createWindow() {
+  Menu.setApplicationMenu(null);
   rollbackFunc = await getRollbackFunc();
   const mainBrowserWindow = new BrowserWindow({
     width: 900,
@@ -34,6 +37,7 @@ async function createWindow() {
     app.dock.setIcon(path.join(__dirname, "../public/icon/icon.icns"));
   }
   configureEvent(mainBrowserWindow);
+  configureGlobalShortcut();
 
   if (process.env.WEBPACK_DEV_SERVER_URL) {
     await mainBrowserWindow.loadURL(process.env.WEBPACK_DEV_SERVER_URL as string);
@@ -81,6 +85,4 @@ if (isDevelopment) {
       app.quit();
     });
   }
-} else {
-  Menu.setApplicationMenu(null);
 }

--- a/src/electron/ConfigureGlobalShortcut.ts
+++ b/src/electron/ConfigureGlobalShortcut.ts
@@ -1,0 +1,43 @@
+import {BrowserWindow, globalShortcut} from "electron";
+
+export const configureGlobalShortcut = (): void => {
+  /**
+   * 刷新页面
+   */
+  globalShortcut.register("F5", (): void => {
+    const focusedWindow = BrowserWindow.getFocusedWindow();
+    if (focusedWindow) {
+      focusedWindow.webContents.reload();
+    }
+  });
+
+  /**
+   * 刷新页面（不使用缓存）
+   */
+  globalShortcut.register("Shift+F5", (): void => {
+    const focusedWindow = BrowserWindow.getFocusedWindow();
+    if (focusedWindow) {
+      focusedWindow.webContents.reloadIgnoringCache();
+    }
+  });
+
+  /**
+   * 最大化窗口
+   */
+  globalShortcut.register("F11", (): void => {
+    const focusedWindow = BrowserWindow.getFocusedWindow();
+    if (focusedWindow) {
+      focusedWindow.setFullScreen(!focusedWindow.isFullScreen());
+    }
+  });
+
+  /**
+   * 调试窗口
+   */
+  globalShortcut.register("Ctrl+Shift+I", (): void => {
+    const focusedWindow = BrowserWindow.getFocusedWindow();
+    if (focusedWindow) {
+      focusedWindow.webContents.openDevTools();
+    }
+  });
+}

--- a/src/views/NavigationFrame.vue
+++ b/src/views/NavigationFrame.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="navigation-box" class="navigation-box">
     <d-layout class="navigation-box">
-      <d-header data-tauri-drag-region v-if="showTitle" class="navigation-header">
+      <d-header data-tauri-drag-region v-if="showTitle && !isLinux" class="navigation-header">
         <title-menu-content/>
       </d-header>
       <d-layout :class="['navigation-box', 'navigation-document-content', { 'show-title': showTitle }]">
@@ -25,6 +25,7 @@ import { IpcMainChannel } from "@/assets/ts/interface/ipc/IpcMainChannel";
 import { ref } from "vue";
 
 const showTitle = ref<boolean>(true);
+const isLinux = process.platform === "linux";
 ipcRenderer.on(IpcMainChannel.ENTER_FULL_SCREEN, () => { showTitle.value = false; });
 ipcRenderer.on(IpcMainChannel.LEAVE_FULL_SCREEN, () => { showTitle.value = true; });
 </script>


### PR DESCRIPTION
fix #5 修复Linux环境下标题栏和菜单栏显示不正确的问题
1. 删除Linux环境下的自定义标题栏
2. 删除菜单栏
3. 注册必要的全局快捷键，修复删除菜单栏后快捷键失效的问题